### PR TITLE
Add element table

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 const serverEdit = require("./components/server-edit.js");
-const { queryResults } = require("./components/query-results.js");
+const queryResults = require("./components/query-results.js");
 const KdbConnection = require("./server/kdb-connection.js");
 const storage = require("./storage/storage");
 const editor = require("./editor/editor");
@@ -14,12 +14,14 @@ module.exports = {
     return {
       servers: new Map(),
       selectServer: undefined,
-      queryResult: undefined,
+      queryResult: [],
       dialog: {
         editMode: true,
         visible: false,
         server: {},
       },
+      resultsPaneSize: 50,
+      resultsPaneHeight: 0,
     };
   },
   methods: {
@@ -79,6 +81,13 @@ module.exports = {
       this.dialog.server = {};
       this.dialog.visible = false;
     },
+    handlePaneResize(e) {
+      console.log(JSON.stringify(e));
+      this.resultsPaneSize = e[1].size;
+      this.resultsPaneHeight =
+        (this.$refs.mainArea.clientHeight * this.resultsPaneSize) / 100;
+      console.log("Results pane height: " + this.resultsPaneHeight);
+    },
   },
   async mounted() {
     const servers = await storage.getServers();
@@ -99,6 +108,10 @@ module.exports = {
         };
       }
     }
+
+    // Calculate required height of results pane
+    this.resultsPaneHeight =
+      (this.$refs.mainArea.clientHeight * this.resultsPaneSize) / 100;
 
     console.log(JSON.stringify(this.servers.get(this.selectServer))); //TODO: remove
   },

--- a/app.js
+++ b/app.js
@@ -112,8 +112,6 @@ module.exports = {
     // Calculate required height of results pane
     this.resultsPaneHeight =
       (this.$refs.mainArea.clientHeight * this.resultsPaneSize) / 100;
-
-    console.log(JSON.stringify(this.servers.get(this.selectServer))); //TODO: remove
   },
   computed: {
     dialogTitle: function () {

--- a/app.js
+++ b/app.js
@@ -90,8 +90,17 @@ module.exports = {
     // automatically connect to the first server in the list
     if (servers.length) {
       this.selectServer = servers[0].id;
-      await this.connect();
+      try {
+        await this.connect();
+      } catch (e) {
+        this.queryResult = {
+          type: "error",
+          data: "failed to connect to server",
+        };
+      }
     }
+
+    console.log(JSON.stringify(this.servers.get(this.selectServer))); //TODO: remove
   },
   computed: {
     dialogTitle: function () {

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,8 +1,8 @@
 const storage = require("./storage/storage");
-const ElementUI = require("element-ui");
+// const ElementUI = require("element-ui");
 const app = require("./app.js");
 
 storage.init();
 
-Vue.use(ElementUI);
+// Vue.use(ElementUI);
 new Vue(app);

--- a/components/query-results.js
+++ b/components/query-results.js
@@ -1,27 +1,5 @@
 const { autoUpdater } = require("electron");
 
-function generateTableHTML(data) {
-  let tableHTML = '<table border="1"><tr>';
-  if (typeof data[0] == "object") {
-    tableHTML += Object.keys(data[0])
-      .map((x) => `<th>${x}</th>`)
-      .join("");
-    tableHTML += "</tr>";
-    tableHTML += data
-      .map(
-        (row) =>
-          `<tr>${Object.values(row)
-            .map((cell) => `<td>${cell}</td>`)
-            .join("")}</tr>`
-      )
-      .join("");
-  } else {
-    tableHTML += data.map((x) => `<td>${x}</td>`).join("");
-  }
-  tableHTML += "</table>";
-  return tableHTML;
-}
-
 const queryResults = {
   props: {
     result: {
@@ -48,6 +26,7 @@ const queryResults = {
   },
 
   computed: {
+    //TODO: work out why this isn't working (div doesn't scroll, only the entire tab pane)
     textDivStyle() {
       return {
         maxHeight: this.paneHeight - this.tabHeight,

--- a/components/query-results.js
+++ b/components/query-results.js
@@ -29,6 +29,8 @@ const queryResults = {
       resText: "",
       resHTML: "",
       resMsg: "",
+      columns: [{ id: "1", label: "placeholder", prop: "col" }],
+      tableData: [{ col: "lorem ipsum" }],
     };
   },
 
@@ -46,13 +48,26 @@ const queryResults = {
               this.resText =
                 "<pre>" + JSON.stringify(res.data, undefined, 2) + "</pre>";
               if (data.length) {
-                outputHTML = generateTableHTML(data);
+                // outputHTML = generateTableHTML(data);
+                console.log("About to set table cols/data");
+                const colnames = Object.keys(data[0]);
+                this.tableData = data;
+                this.columns = colnames.map((c) => {
+                  return {
+                    prop: c,
+                    label: c,
+                    minWidth: "180px",
+                  };
+                });
               } else {
                 for (let x in data) {
                   outputHTML += x + " | " + data[x] + "<br />";
                 }
               }
               this.activeTab = "tbl";
+              console.log("column defs are: " + JSON.stringify(this.columns));
+              console.log("tableData is " + JSON.stringify(this.tableData));
+              this.tableData = [{ col1: "lorem ipsum" }]; //TODO: temp
             } else {
               this.resText = data;
               this.activeTab = "txt";
@@ -70,8 +85,23 @@ const queryResults = {
   template:
     /*html*/
     `<el-tabs v-model="activeTab" type="card">
-    <el-tab-pane label="Table" name="tbl"><div v-html="resHTML"></div></el-tab-pane>
-    <el-tab-pane label="Text" name="txt"><div v-html="resText"></div></el-tab-pane>
+    <el-tab-pane label="Table" name="tbl">
+    <template>
+      <el-table 
+        :data="tableData"
+        style="width: 100%;">
+        <el-table-column v-for="column in columns" 
+                        :key="column.id"
+                        :prop="column.prop"
+                        :label="column.label"
+                        :min-width="column.minWidth">
+        </el-table-column>
+      </el-table>
+    </template>
+    </el-tab-pane>
+    <el-tab-pane label="Text" name="txt">
+      <div v-html="resText"></div>
+      </el-tab-pane>
     <el-tab-pane label="Message" name="msg">{{ resMsg }}</el-tab-pane>
   </el-tabs>`,
 };

--- a/components/query-results.js
+++ b/components/query-results.js
@@ -1,3 +1,5 @@
+const { autoUpdater } = require("electron");
+
 function generateTableHTML(data) {
   let tableHTML = '<table border="1"><tr>';
   if (typeof data[0] == "object") {
@@ -21,7 +23,16 @@ function generateTableHTML(data) {
 }
 
 const queryResults = {
-  props: ["result"],
+  props: {
+    result: {
+      // type: Array,
+      required: true,
+    },
+    paneHeight: {
+      type: Number,
+      required: true,
+    },
+  },
 
   data() {
     return {
@@ -29,9 +40,21 @@ const queryResults = {
       resText: "",
       resHTML: "",
       resMsg: "",
-      columns: [{ id: "1", label: "placeholder", prop: "col" }],
-      tableData: [{ col: "lorem ipsum" }],
+      columns: [],
+      tableData: [],
+
+      tabHeight: 62, //TODO: work this out
     };
+  },
+
+  computed: {
+    textDivStyle() {
+      return {
+        maxHeight: this.paneHeight - this.tabHeight,
+        overflow: "auto",
+        backgroundColor: "white",
+      };
+    },
   },
 
   watch: {
@@ -56,7 +79,7 @@ const queryResults = {
                   return {
                     prop: c,
                     label: c,
-                    minWidth: "180px",
+                    minWidth: "20px",
                   };
                 });
               } else {
@@ -67,7 +90,6 @@ const queryResults = {
               this.activeTab = "tbl";
               console.log("column defs are: " + JSON.stringify(this.columns));
               console.log("tableData is " + JSON.stringify(this.tableData));
-              this.tableData = [{ col1: "lorem ipsum" }]; //TODO: temp
             } else {
               this.resText = data;
               this.activeTab = "txt";
@@ -89,21 +111,26 @@ const queryResults = {
     <template>
       <el-table 
         :data="tableData"
+        size="mini"
+        border
+        :max-height="paneHeight - tabHeight"
+        empty-text="No Data"
         style="width: 100%;">
         <el-table-column v-for="column in columns" 
                         :key="column.id"
                         :prop="column.prop"
                         :label="column.label"
+                        sortable
                         :min-width="column.minWidth">
         </el-table-column>
       </el-table>
     </template>
     </el-tab-pane>
     <el-tab-pane label="Text" name="txt">
-      <div v-html="resText"></div>
+      <div :style="textDivStyle" v-html="resText"></div>
       </el-tab-pane>
     <el-tab-pane label="Message" name="msg">{{ resMsg }}</el-tab-pane>
   </el-tabs>`,
 };
 
-module.exports = { queryResults };
+module.exports = queryResults;

--- a/components/query-results.js
+++ b/components/query-results.js
@@ -1,5 +1,99 @@
 const { autoUpdater } = require("electron");
 
+const formatData = (data) => {
+  // Q has different types for date, time and datetime but these are all converted to JS Date
+  // object by node-q.
+  // The only way to know if a datetime is a date or a time is to check if time is zero (=> date)
+  // or date is 1 Jan 2000 (=> time, unless the date *really is* 1 Jan 2000....) - so apply
+  // some heuristics to work out how to format each column based on the data it contains.
+  // see https://www.npmjs.com/package/node-q#types
+
+  const _getDtType = (v) => {
+    if (v instanceof Date) {
+      if (
+        v.getHours() === 0 &&
+        v.getMinutes() === 0 &&
+        v.getSeconds() === 0 &&
+        v.getMilliseconds() === 0
+      ) {
+        return "date";
+      } else if (
+        v.getFullYear() === 2000 &&
+        v.getMonth() === 0 &&
+        v.getDate() === 1
+      ) {
+        if (v.getMilliseconds() > 0) {
+          return "timefull";
+        } else {
+          return "time";
+        }
+      } else {
+        return "datetime";
+      }
+    } else {
+      return "none";
+    }
+  };
+
+  const _formatDt = (val, dtType) => {
+    if (val instanceof Date) {
+      const dtISOStr = val.toISOString();
+      const [date, timeFull] = dtISOStr.split("T");
+      const [time, millisec] = timeFull.split(".");
+
+      switch (dtType) {
+        case "time":
+          return time;
+          break;
+        case "timefull":
+          return `${timeFull.replace(/Z$/, "")}`;
+        case "date":
+          return date;
+          break;
+        default:
+          return `${date} ${time}`;
+          break;
+      }
+    } else {
+      return val;
+    }
+  };
+
+  if (data instanceof Array) {
+    const colnames = Object.keys(data[0]);
+    let colDtType = {};
+
+    // For each column, if a Date object, establish by empirical means if it contains date, time or datetime
+    colnames.forEach((c) => {
+      let colDtTypeCount = {};
+      colDtTypeCount = data
+        .map((r) => r[c])
+        .reduce(
+          (acc, val) => {
+            acc[_getDtType(val)]++;
+            return acc;
+          },
+          { date: 0, time: 0, timefull: 0, datetime: 0, none: 0 }
+        );
+
+      // Get largest count and assume that's the datetime type for this column
+      colDtType[c] = Object.keys(colDtTypeCount).reduce((a, b) =>
+        colDtTypeCount[a] > colDtTypeCount[b] ? a : b
+      );
+    });
+
+    // Now reformat dates as strings, in-place
+    data.forEach((r) => {
+      colnames.forEach((c) => {
+        if (colDtType[c] !== "none") {
+          r[c] = _formatDt(r[c], colDtType[c]);
+        }
+      });
+    });
+  }
+  return data;
+};
+
 const queryResults = {
   props: {
     result: {
@@ -21,7 +115,7 @@ const queryResults = {
       columns: [],
       tableData: [],
 
-      tabHeight: 62, //TODO: work this out
+      tabHeight: 58, //TODO: work this out
     };
   },
 
@@ -53,7 +147,7 @@ const queryResults = {
                 // outputHTML = generateTableHTML(data);
                 console.log("About to set table cols/data");
                 const colnames = Object.keys(data[0]);
-                this.tableData = data;
+                this.tableData = formatData(data);
                 this.columns = colnames.map((c) => {
                   return {
                     prop: c,

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -31,7 +31,7 @@ module.exports = new Promise((resolve) => {
     monaco.editor.defineTheme("kdb", theme);
 
     const editor = monaco.editor.create(document.getElementById("editor"), {
-      value: "([] c1:1000+til 6; c2:`a`b`c`a`b`a; c3:10*1+til 6)",
+      value: "([] c1:1000+til 100; c2:100?`a`b`c; c3:10*1+til 100)",
       language: "kdb/q",
       theme: "kdb",
       minimap: {

--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
       rel="stylesheet"
       href="node_modules/element-ui/lib/theme-chalk/index.css"
     />
-    <script src="node_modules/vue/dist/vue.js"></script>
-    <script src="node_modules/element-ui/lib/index.js"></script>
+
     <link rel="stylesheet" href="node_modules/splitpanes/dist/splitpanes.css" />
 
     <style>
@@ -28,6 +27,9 @@
       }
       #main-area {
         flex: auto;
+        /* min-height: 90vh;
+        max-height: 90vh; */
+        height: 50%;
         border: 1px solid lightgray;
       }
       body {
@@ -112,11 +114,28 @@
           </el-button-group>
         </div>
 
-        <div id="main-area">
-          <splitpanes class="default-theme" horizontal>
-            <pane id="editor" size="50" min-size="10" max-size="90"></pane>
-            <pane id="results" size="50" min-size="10" max-size="90">
-              <query-results v-bind:result="queryResult"></query-results>
+        <div id="main-area" ref="mainArea">
+          <splitpanes
+            class="default-theme"
+            @resize="handlePaneResize($event)"
+            horizontal
+          >
+            <pane
+              id="editor"
+              :size="100 - resultsPaneSize"
+              min-size="10"
+              max-size="90"
+            ></pane>
+            <pane
+              id="results"
+              :size="resultsPaneSize"
+              min-size="10"
+              max-size="90"
+            >
+              <query-results
+                v-bind:result="queryResult"
+                :pane-height="resultsPaneHeight"
+              ></query-results>
             </pane>
           </splitpanes>
         </div>
@@ -124,5 +143,7 @@
     </div>
   </body>
 
+  <script src="node_modules/vue/dist/vue.js"></script>
+  <script src="node_modules/element-ui/lib/index.js"></script>
   <script src="bootstrap.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         overflow: auto;
         /* flex: auto; */
       }
-      table,
+      /* table,
       th,
       td {
         border: 1px solid lightgray;
@@ -48,7 +48,7 @@
         font-family: "Lucida Sans";
         text-align: left;
         margin-bottom: 10px;
-      }
+      } */
     </style>
   </head>
   <body>


### PR DESCRIPTION
Tabulated results now use ElementUI table component; resizing and scrolling seems to work correctly.

There is an issue with the Text tab when the results are too large for the pane: the entire pane scrolls, including the tab control, rather than just the results.  I have not managed to figure out why, or how to fix this.