### PR TITLE
Switch to using React Fast Refresh for module reload

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,5 +4,5 @@
     "@babel/preset-react",
     "@babel/preset-typescript"
   ],
-  "plugins": [["@babel/transform-runtime"], ["react-hot-loader/babel"]]
+  "plugins": [["@babel/transform-runtime"]]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@babel/preset-react": "^7.9.4",
         "@babel/preset-typescript": "^7.9.0",
         "@babel/runtime": "^7.14.6",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
         "@types/electron-json-storage": "^4.5.0",
         "@types/uuid": "^8.3.1",
         "babel-loader": "^8.1.0",
@@ -43,6 +44,7 @@
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^4.5.2",
         "monaco-editor-webpack-plugin": "^4.1.1",
+        "react-refresh": "^0.9.0",
         "style-loader": "^3.1.0",
         "webpack-cli": "^4.*",
         "webpack-dev-server": "^3.11.2"
@@ -2114,6 +2116,62 @@
       "version": "1.10.196",
       "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.196.tgz",
       "integrity": "sha512-eImlYYB/ZJH8Y3t2d/JbjxwSwWVeiQ7x+Xl5mTlTAlByzAiEs7tB3LUOEEz0XrlasvYV9ynq2i8b1+Gi/+KlMQ=="
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
+      "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-html": "^0.0.7",
+        "error-stack-parser": "^2.0.6",
+        "html-entities": "^1.2.1",
+        "native-url": "^0.2.6",
+        "schema-utils": "^2.6.5",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">= 10.x"
+      },
+      "peerDependencies": {
+        "@types/webpack": "4.x",
+        "react-refresh": ">=0.8.3 <0.10.0",
+        "sockjs-client": "^1.4.0",
+        "type-fest": "^0.13.1",
+        "webpack": ">=4.43.0 <6.0.0",
+        "webpack-dev-server": "3.x",
+        "webpack-hot-middleware": "2.x",
+        "webpack-plugin-serve": "0.x || 1.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        },
+        "sockjs-client": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        },
+        "webpack-hot-middleware": {
+          "optional": true
+        },
+        "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -5484,6 +5542,15 @@
         "errno": "cli.js"
       }
     },
+    "node_modules/error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "dev": true,
+      "dependencies": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
@@ -8207,6 +8274,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/native-url": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
+      "integrity": "sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==",
+      "dev": true,
+      "dependencies": {
+        "querystring": "^0.2.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -9276,6 +9352,15 @@
       "peerDependencies": {
         "@types/react": "^17.x",
         "react": "^17.x"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/read-config-file": {
@@ -10370,6 +10455,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
+      "dev": true
     },
     "node_modules/stat-mode": {
       "version": "1.0.0",
@@ -13830,6 +13921,28 @@
       "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.196.tgz",
       "integrity": "sha512-eImlYYB/ZJH8Y3t2d/JbjxwSwWVeiQ7x+Xl5mTlTAlByzAiEs7tB3LUOEEz0XrlasvYV9ynq2i8b1+Gi/+KlMQ=="
     },
+    "@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
+      "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "^0.0.7",
+        "error-stack-parser": "^2.0.6",
+        "html-entities": "^1.2.1",
+        "native-url": "^0.2.6",
+        "schema-utils": "^2.6.5",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -16515,6 +16628,15 @@
         "prr": "~1.0.1"
       }
     },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "dev": true,
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "es-abstract": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
@@ -18606,6 +18728,15 @@
         }
       }
     },
+    "native-url": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
+      "integrity": "sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==",
+      "dev": true,
+      "requires": {
+        "querystring": "^0.2.0"
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -19417,6 +19548,12 @@
         "monaco-editor": "*",
         "prop-types": "^15.7.2"
       }
+    },
+    "react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "dev": true
     },
     "read-config-file": {
       "version": "6.2.0",
@@ -20335,6 +20472,12 @@
       "requires": {
         "frac": "~1.1.2"
       }
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
+      "dev": true
     },
     "stat-mode": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime": "^7.14.6",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@types/electron-json-storage": "^4.5.0",
     "@types/uuid": "^8.3.1",
     "babel-loader": "^8.1.0",
@@ -51,6 +52,7 @@
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^4.5.2",
     "monaco-editor-webpack-plugin": "^4.1.1",
+    "react-refresh": "^0.9.0",
     "style-loader": "^3.1.0",
     "webpack-cli": "^4.*",
     "webpack-dev-server": "^3.11.2"

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,3 @@
-import { hot } from 'react-hot-loader/root';
 import React, { FunctionComponent, useState } from 'react'
 import { ipcRenderer } from "electron"
 import { ThemeProvider } from '@fluentui/react'
@@ -43,4 +42,4 @@ const App:FunctionComponent = () => {
   )
 }
 
-export default hot(App)
+export default App

--- a/webpack.react.config.js
+++ b/webpack.react.config.js
@@ -1,13 +1,16 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
 
 module.exports = {
   resolve: {
     extensions: [".tsx", ".ts", ".js"],
     mainFields: ["main", "module", "browser"],
   },
-  entry: ['react-hot-loader/patch', "./src/index.tsx"],
+  entry: "./src/index.tsx",
   target: "electron-renderer",
   devtool: "source-map",
   module: {
@@ -17,6 +20,13 @@ module.exports = {
         exclude: /node_modules/,
         use: {
           loader: "babel-loader",
+          options: {
+            // ... other options
+            plugins: [
+              // ... other plugins
+              isDevelopment && require.resolve('react-refresh/babel'),
+            ].filter(Boolean),
+          },
         },
       },
       {
@@ -41,9 +51,10 @@ module.exports = {
     filename: 'app.js'
   },
   plugins: [
+    isDevelopment && new ReactRefreshWebpackPlugin(),
     new MonacoWebpackPlugin(),
     new HtmlWebpackPlugin({
       title: "KBD Studio 2"
-    })
+    }),
   ],
 };


### PR DESCRIPTION
Swaps out react-hot-loader for Fast Refresh.

Disclaimer: Fast Refresh webpack plugin is experimental and not yet stable but it seems to work fine for our current uses. More info here: https://github.com/pmmmwh/react-refresh-webpack-plugin/