### PR TITLE
tab name now includes filename

### DIFF
--- a/src/components/ServerInterface.tsx
+++ b/src/components/ServerInterface.tsx
@@ -13,10 +13,14 @@ import Split from 'react-split'
 type ServerInterfaceProps = {
   connection: KdbConnection;
   visible: boolean;
+  filename?: string;
+  onFilenameChanged: (scriptName: string) => void;
 };
 
 const ServerInterface: FC<ServerInterfaceProps> = ({
   connection,
+  filename,
+  onFilenameChanged,
   visible = false,
 }: ServerInterfaceProps) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -91,7 +95,7 @@ const ServerInterface: FC<ServerInterfaceProps> = ({
           minWidth: 0 
         }}
         >
-          <EditorWindow onExecuteQuery={executeQuery} />
+          <EditorWindow onExecuteQuery={executeQuery} onFilenameChanged={onFilenameChanged} filename={filename}/>
           <ResultsWindow
             results={results}
             isLoading={isLoading}


### PR DESCRIPTION
Added filename to the tab, and expanded functionality to provide load / save and save-as behaviour:

![image](https://user-images.githubusercontent.com/1098110/128413414-2378a477-7380-44d4-a6c7-043acc533694.png)

Note, the previous version had a bug, when a file was opened ipcMain raised an event that was handled by all editor windows, so all would update to the new file contents. Updated to use `ipcRenderer.invoke` and `ipcMain.handle` instead.